### PR TITLE
Remove mapbox key, switch to Sentinel satellite

### DIFF
--- a/src/config/backgrounds.ts
+++ b/src/config/backgrounds.ts
@@ -28,14 +28,15 @@ export const backgroundConfig = makeConfig([
     source: {
       id: 'satellite',
       type: 'raster',
-      url: 'mapbox://mapbox.satellite',
+      tiles: [
+        'https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857/default/GoogleMapsCompatible/{z}/{y}/{x}.png'
+      ],
       tileSize: 256,
     },
     layer: {
       id: 'bg-satellite',
       source: 'satellite',
       type: 'raster',
-      'source-layer': 'mapbox_satellite_full',
     },
   },
 ]);

--- a/src/map/MapViewport.tsx
+++ b/src/map/MapViewport.tsx
@@ -12,8 +12,6 @@ import _ from 'lodash';
 
 import { backgroundConfig, BackgroundName } from '../config/backgrounds';
 
-const MAPBOX_KEY = 'pk.eyJ1IjoidG9tcnVzc2VsbCIsImEiOiJjaXZpMTFpdGkwMDQ1MnptcTh4ZzRzeXNsIn0.ZSvSOHSsWBQ44QNhA71M6Q';
-
 function visible(isVisible: boolean): 'visible' | 'none' {
   return isVisible ? 'visible' : 'none';
 }
@@ -68,9 +66,9 @@ export const MapViewport = ({ layersFunction, background, onHover, onClick, pick
       onClick={(info) => deckRef.current && onClick(info, deckRef.current)}
       ContextProvider={MapContext.Provider}
     >
-      <StaticMap mapStyle={backgroundStyle} mapboxApiAccessToken={MAPBOX_KEY} attributionControl={false} />
+      <StaticMap mapStyle={backgroundStyle} attributionControl={false} />
       <AttributionControl
-        customAttribution='Background map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, style &copy; <a href="https://carto.com/attributions">CARTO</a>, satellite imagery via &copy; <a href="https://www.mapbox.com/">MapBox</a>'
+        customAttribution='Background map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, style &copy; <a href="https://carto.com/attributions">CARTO</a>. Satellite imagery: <a href="https://s2maps.eu">Sentinel-2 cloudless - https://s2maps.eu</a> by <a href="https://eox.at">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2020)'
         compact={false}
         style={{
           right: 0,


### PR DESCRIPTION
As an alternative to fully moving background layers to Deck.GL, this change only switches the satellite raster to Sentinel-derived tiles, and removes the Mapbox API key from the code.

More testing is needed to see if the Mapbox notice to provide an API key will be consistently hidden, or if it will appear sometimes because the key is not provided - in which case we'd need to go back to considering the more complex approach.

For satellite attribution, the exact text and links from the tile provider's site has been copied, but maybe we'd have an idea of how to make it more concise while still following the provider guidelines.