### PR TITLE
Add map labels

### DIFF
--- a/src/MapPage.tsx
+++ b/src/MapPage.tsx
@@ -7,7 +7,6 @@ import { DataMap } from './map/DataMap';
 import { NetworkControl } from './controls/NetworkControl';
 import { useLayerSelection } from './controls/use-layer-selection';
 import { ViewName, VIEWS } from './config/views';
-import { BackgroundName } from './config/backgrounds';
 import { LayerName } from './config/layers';
 import { HazardsControl } from './controls/HazardsControl';
 import { useNetworkSelection } from './controls/use-network-selection';
@@ -27,8 +26,6 @@ function firstTrue(object) {
 }
 
 export const MapPage: FC<MapViewProps> = ({ view }) => {
-  const [background, setBackground] = useState<BackgroundName>('light');
-
   const viewLayerNames = useMemo<LayerName[]>(() => VIEWS[view].layers as LayerName[], [view]);
   // const layerDefinitions = useMemo(
   //   () => viewLayerNames.map((layerName) => ({ ...LAYERS[layerName], key: layerName })),
@@ -114,13 +111,7 @@ export const MapPage: FC<MapViewProps> = ({ view }) => {
         </Box>
       </Drawer>
       <Box position="absolute" top={64} left={sidebarWidth} right={0} bottom={0}>
-        <DataMap
-          background={background}
-          onBackground={setBackground}
-          layerSelection={layerSelection}
-          styleParams={styleParams}
-          view={view}
-        />
+        <DataMap layerSelection={layerSelection} styleParams={styleParams} view={view} />
       </Box>
     </>
   );

--- a/src/config/deck-layers.ts
+++ b/src/config/deck-layers.ts
@@ -119,6 +119,28 @@ export function selectionLayer(feature, zoom) {
   );
 }
 
+export function labelsLayer(isRetina: boolean) {
+  const scale = isRetina ? '@2x' : '';
+
+  return rasterTileLayer(
+    {
+      [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+      transparentColor: [255, 255, 255, 0],
+    },
+    {
+      id: 'labels',
+      tileSize: isRetina ? 512 : 256,
+      data: [
+        `https://a.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}${scale}.png`,
+        `https://b.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}${scale}.png`,
+        `https://c.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}${scale}.png`,
+        `https://d.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}${scale}.png`,
+      ],
+      refinementStrategy: 'no-overlap',
+    },
+  );
+}
+
 export const DECK_LAYERS = makeConfig<any, string>([
   {
     id: 'elec_edges_high',

--- a/src/map/DataMap.tsx
+++ b/src/map/DataMap.tsx
@@ -132,7 +132,7 @@ export const DataMap = ({ background, view, layerSelection, styleParams, onBackg
     [vectorLayerIds],
   );
 
-  const deckLayersFunction = useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature);
+  const deckLayersFunction = useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature, true);
 
   const selectedSearchResult = useRecoilValue(placeSearchSelectedResultState);
   const searchBounds = selectedSearchResult?.boundingBox;

--- a/src/map/DataMap.tsx
+++ b/src/map/DataMap.tsx
@@ -12,10 +12,11 @@ import { DECK_LAYERS } from '../config/deck-layers';
 import { MapLegend } from './legend/MapLegend';
 import { MapSearch } from './search/MapSearch';
 import { LegendContent } from './legend/LegendContent';
-import { MapLayerSelection } from './MapLayerSelection';
+import { MapLayerSelection } from './layers/MapLayerSelection';
 import { Box } from '@material-ui/core';
 import { placeSearchSelectedResultState } from './search/search-state';
 import { useRecoilValue } from 'recoil';
+import { backgroundState } from './layers/layers-state';
 
 export interface RasterHover {
   type: 'raster';
@@ -72,7 +73,8 @@ function processVectorHover(layerId, info): VectorHover {
 const pickingRadius = 8;
 const rasterRegex = /^(coastal|fluvial|surface|cyclone)/;
 
-export const DataMap = ({ background, view, layerSelection, styleParams, onBackground }) => {
+export const DataMap = ({ view, layerSelection, styleParams }) => {
+  const background = useRecoilValue(backgroundState);
   const [hoveredVectors, setHoveredVectors] = useState<VectorHover[]>([]);
   const [hoveredRasters, setHoveredRasters] = useState<RasterHover[]>([]);
   const [hoverXY, setHoverXY] = useState<[number, number]>(null);
@@ -155,10 +157,10 @@ export const DataMap = ({ background, view, layerSelection, styleParams, onBackg
       </MapViewport>
       <Box position="absolute" top={0} left={0} ml={3} m={1} zIndex={1000}>
         <Box mt={1}>
-          <MapLayerSelection background={background} onBackground={onBackground} />
+          <MapSearch />
         </Box>
         <Box mt={1}>
-          <MapSearch />
+          <MapLayerSelection />
         </Box>
       </Box>
       <Box position="absolute" bottom={0} left={0} m={1} ml={3} zIndex={1000}>

--- a/src/map/DataMap.tsx
+++ b/src/map/DataMap.tsx
@@ -16,7 +16,7 @@ import { MapLayerSelection } from './layers/MapLayerSelection';
 import { Box } from '@material-ui/core';
 import { placeSearchSelectedResultState } from './search/search-state';
 import { useRecoilValue } from 'recoil';
-import { backgroundState } from './layers/layers-state';
+import { backgroundState, showLabelsState } from './layers/layers-state';
 
 export interface RasterHover {
   type: 'raster';
@@ -75,6 +75,8 @@ const rasterRegex = /^(coastal|fluvial|surface|cyclone)/;
 
 export const DataMap = ({ view, layerSelection, styleParams }) => {
   const background = useRecoilValue(backgroundState);
+  const showLabels = useRecoilValue(showLabelsState);
+
   const [hoveredVectors, setHoveredVectors] = useState<VectorHover[]>([]);
   const [hoveredRasters, setHoveredRasters] = useState<RasterHover[]>([]);
   const [hoverXY, setHoverXY] = useState<[number, number]>(null);
@@ -134,7 +136,7 @@ export const DataMap = ({ view, layerSelection, styleParams }) => {
     [vectorLayerIds],
   );
 
-  const deckLayersFunction = useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature, true);
+  const deckLayersFunction = useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature, showLabels);
 
   const selectedSearchResult = useRecoilValue(placeSearchSelectedResultState);
   const searchBounds = selectedSearchResult?.boundingBox;

--- a/src/map/layers/MapLayerSelection.tsx
+++ b/src/map/layers/MapLayerSelection.tsx
@@ -1,6 +1,9 @@
-import { Box, Button, ButtonGroup, Typography } from '@material-ui/core';
+import { Button, ButtonGroup, Typography } from '@material-ui/core';
 import { Layers as LayersIcon } from '@material-ui/icons';
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { backgroundState } from './layers-state';
 
 const config = {
   satellite: {
@@ -11,7 +14,8 @@ const config = {
   },
 };
 
-export const MapLayerSelection = ({ background, onBackground }) => {
+export const MapLayerSelection = () => {
+  const [background, setBackground] = useRecoilState(backgroundState);
   const [showHint, setShowHint] = useState(false);
 
   const other = background === 'satellite' ? 'light' : 'satellite';
@@ -21,7 +25,7 @@ export const MapLayerSelection = ({ background, onBackground }) => {
     <ButtonGroup>
       <Button
         aria-label="Toggle map background"
-        onClick={() => onBackground(other)}
+        onClick={() => setBackground(other)}
         onMouseEnter={() => setShowHint(true)}
         onMouseLeave={() => setShowHint(false)}
         variant="contained"

--- a/src/map/layers/MapLayerSelection.tsx
+++ b/src/map/layers/MapLayerSelection.tsx
@@ -1,9 +1,9 @@
-import { Button, ButtonGroup, Typography } from '@material-ui/core';
+import { Box, Button, Checkbox, FormControlLabel, Paper, Typography } from '@material-ui/core';
 import { Layers as LayersIcon } from '@material-ui/icons';
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { backgroundState } from './layers-state';
+import { backgroundState, showLabelsState } from './layers-state';
 
 const config = {
   satellite: {
@@ -15,29 +15,49 @@ const config = {
 };
 
 export const MapLayerSelection = () => {
+  const [showPopover, setShowPopover] = useState(false);
+
   const [background, setBackground] = useRecoilState(backgroundState);
-  const [showHint, setShowHint] = useState(false);
+  const [showLabels, setShowLabels] = useRecoilState(showLabelsState);
 
   const other = background === 'satellite' ? 'light' : 'satellite';
 
-  // const currentConfig = config[background];
+  const buttonStyle = showPopover ? { borderTopRightRadius: 0, borderBottomRightRadius: 0 } : {};
   return (
-    <ButtonGroup>
+    <Box
+      onMouseEnter={() => setShowPopover(true)}
+      onMouseLeave={() => setShowPopover(false)}
+      style={{ display: 'flex', pointerEvents: 'none' }}
+    >
       <Button
         aria-label="Toggle map background"
         onClick={() => setBackground(other)}
-        onMouseEnter={() => setShowHint(true)}
-        onMouseLeave={() => setShowHint(false)}
         variant="contained"
-        style={{ paddingInline: 0, backgroundColor: 'white' }}
+        style={{
+          paddingInline: 0,
+          backgroundColor: 'white',
+          minWidth: 'auto',
+          width: '40px',
+          height: '36px',
+          pointerEvents: 'auto',
+          ...buttonStyle,
+        }}
       >
         <LayersIcon />
       </Button>
-      {showHint && (
-        <Button variant="contained" color="default" style={{ textTransform: 'none' }}>
-          <Typography>Switch to {config[other].label} background</Typography>
-        </Button>
+      {showPopover && (
+        <Paper style={{ overflow: 'hidden', pointerEvents: 'auto', borderTopLeftRadius: 0 }}>
+          <Box px={2} py="6px" height={36} bgcolor="#ddd" display="flex">
+            <Typography>Switch to {config[other].label} background</Typography>
+          </Box>
+          <Box px={2}>
+            <FormControlLabel
+              label="Show labels"
+              control={<Checkbox checked={showLabels} onChange={(e, checked) => setShowLabels(checked)} />}
+            />
+          </Box>
+        </Paper>
       )}
-    </ButtonGroup>
+    </Box>
   );
 };

--- a/src/map/layers/layers-state.ts
+++ b/src/map/layers/layers-state.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+
+import { BackgroundName } from '../../config/backgrounds';
+
+export const backgroundState = atom<BackgroundName>({
+  key: 'background',
+  default: 'light',
+});
+
+export const showLabelsState = atom<boolean>({
+  key: 'showLabels',
+  default: true,
+});

--- a/src/map/use-map-layers.ts
+++ b/src/map/use-map-layers.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 import { LayerDefinition, LayerName, LAYERS } from '../config/layers';
 import { ViewName, VIEWS } from '../config/views';
-import { DECK_LAYERS, selectionLayer } from '../config/deck-layers';
+import { DECK_LAYERS, labelsLayer, selectionLayer } from '../config/deck-layers';
 import { VectorHover } from './DataMap';
 
 /**
@@ -54,6 +54,7 @@ function getDeckLayers(
   zoom: number,
   styleParams: any,
   selectedFeature: VectorHover,
+  showLabels: boolean,
 ) {
   const resLayers = [];
 
@@ -80,6 +81,10 @@ function getDeckLayers(
     resLayers.push(selectionLayer(feature, zoom));
   }
 
+  if (showLabels) {
+    resLayers.push(labelsLayer(true));
+  }
+
   return resLayers;
 }
 
@@ -87,9 +92,9 @@ export function useDeckLayersSpec(dataLayerSelection, view) {
   return useMemo(() => getDeckLayersSpec(dataLayerSelection, view), [dataLayerSelection, view]);
 }
 
-export function useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature) {
+export function useMapLayersFunction(deckLayersSpec, styleParams, selectedFeature, showLabels) {
   return useCallback(
-    ({ zoom }) => getDeckLayers(deckLayersSpec, zoom, styleParams, selectedFeature),
-    [deckLayersSpec, styleParams, selectedFeature],
+    ({ zoom }) => getDeckLayers(deckLayersSpec, zoom, styleParams, selectedFeature, showLabels),
+    [deckLayersSpec, styleParams, selectedFeature, showLabels],
   );
 }


### PR DESCRIPTION
Closes #26 (the part about map labels). Leaving the admin boundaries for a separate issue/PR.

The labels are based on CARTO labels-only raster tiles.
The labels are toggleable through a checkbox in the map layers button popover.

Currently the tiles fetched will always be retina-scale (512x512) as I haven't found an easy way to get the appropriate scale from Deck (Leaflet, for example, handles retina out of the box by replacing a `{scale}` string in the tiles URL automatically, but here we should figure out our own mechanism if always using the retina tiles proves problematic in the future).