### PR TITLE
Fix: raster values

### DIFF
--- a/src/map/legend/use-color-map-values.ts
+++ b/src/map/legend/use-color-map-values.ts
@@ -8,15 +8,17 @@ export function useRasterColorMapValues(colorScheme: string, stretchRange: [numb
     loading,
     error,
     data: { colormap: colorMapValues = null } = {},
-  } = useFetch(`/raster/colormap?colormap=${colorScheme}&stretch_range=[${rangeMin},${rangeMax}]`, { persist: true }, [
-    colorScheme,
-    rangeMin,
-    rangeMax,
-  ]);
+  } = useFetch(`/raster/colormap?colormap=${colorScheme}&stretch_range=[0,1]`, { persist: false }, [colorScheme]);
+
+  const rangeSize = rangeMax - rangeMin;
 
   const result = useMemo(
-    () => colorMapValues?.map(({ value, rgba: [r, g, b] }) => ({ value, color: `rgb(${r},${g},${b})` })),
-    [colorMapValues],
+    () =>
+      colorMapValues?.map(({ value, rgba: [r, g, b] }) => ({
+        value: rangeMin + value * rangeSize,
+        color: `rgb(${r},${g},${b})`,
+      })),
+    [colorMapValues, rangeMin, rangeSize],
   );
 
   return {


### PR DESCRIPTION
Closes #37.

The commits in this PR only contain some optimisations of the colormap fetching.
The main solution to our problem is a fix released in https://github.com/DHI-GRAS/terracotta/releases/tag/v0.7.5 - upgrade the software with:

```
conda activate infrariskvis
pip install terracotta --upgrade
```