### PR TITLE
Fix adaptation options no. of days < 15

### DIFF
--- a/backend/backend/app/schemas.py
+++ b/backend/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import Any, Generic, Literal, TypeVar
-from pydantic import BaseModel, conint, root_validator
+from pydantic import BaseModel, conint, validator
 from pydantic.generics import GenericModel
 
 
@@ -118,6 +118,17 @@ class AdaptationVariables(DataVariables):
 
 class AdaptationCostBenefitRatioParameters(DataParameters):
     eael_days: conint(ge=1, le=30)
+
+    @validator('eael_days')
+    def fix_eael_days(cls, eael_days) -> float:
+        """
+        The data for `AdaptationCostBenefit.avoided_eael_mean` is erroneous and
+        should be modified in the meantime. This validator adds a fudge factor
+        to account for the multiplicative error in the data.
+
+        TODO: fix the data so we don't need this function.
+        """
+        return eael_days / 15
 
 
 class Adaptation(AdaptationDimensions, AdaptationVariables):

--- a/src/details/features/adaptation/AdaptationSection.tsx
+++ b/src/details/features/adaptation/AdaptationSection.tsx
@@ -40,6 +40,7 @@ function makeAdaptationCsv(options: Adaptation[]) {
   ).join('\n');
 }
 
+// TODO: remove factor when data is updated
 const HORRIBLE_HACK_FACTOR = 1/15;
 export const AdaptationSection = ({ fd }) => {
   const options : Adaptation[] = fd?.adaptation.map(

--- a/src/sidebar/networks/AdaptationControl.tsx
+++ b/src/sidebar/networks/AdaptationControl.tsx
@@ -38,8 +38,7 @@ function makeOptions(values, labelFn = (x) => x) {
     label: labelFn(val),
   }));
 }
-const HORRIBLE_HACK_FACTOR = 1/15;
-const EAEL_DAYS_MARKS = [1, 5, 10, 15, 20, 25, 30].map((x) => ({ value: x * HORRIBLE_HACK_FACTOR, label: x }));
+const EAEL_DAYS_MARKS = [1, 5, 10, 15, 20, 25, 30].map((x) => ({ value: x, label: x }));
 const CostBenefitRatioInputs: FC = () => {
   const [eaelDays, setEaelDays] = useRecoilState(adaptationCostBenefitRatioEaelDaysState);
 
@@ -52,9 +51,9 @@ const CostBenefitRatioInputs: FC = () => {
         id="adaptation-cost-benefit-eael-days"
         value={eaelDays}
         onChange={(e, value: number) => setEaelDays(value)}
-        min={1*HORRIBLE_HACK_FACTOR}
-        max={30*HORRIBLE_HACK_FACTOR}
-        step={1*HORRIBLE_HACK_FACTOR}
+        min={1}
+        max={30}
+        step={1}
         marks={EAEL_DAYS_MARKS}
         valueLabelDisplay="auto"
       />

--- a/src/state/layers/networks.ts
+++ b/src/state/layers/networks.ts
@@ -35,10 +35,9 @@ export const adaptationFieldState = atom<
   default: 'avoided_ead_mean',
 });
 
-const HORRIBLE_HACK_FACTOR = 1/15;
 export const adaptationCostBenefitRatioEaelDaysState = atom<number>({
   key: 'adaptationCostBenefitRatioEaelDaysState',
-  default: 15 * HORRIBLE_HACK_FACTOR,
+  default: 15,
 });
 
 export const adaptationDataParamsStateEffect: StateEffect<AdaptationOptionParams> = (


### PR DESCRIPTION
There is a problem with some data in the database... I think the `adaptation_cost_benefit.avoided_eael_*` values? These values are multiplied by `eael_days`, which is sent from the FE. The `adaptation_cost_benefit.avoided_eael_*` values are corrected with a fudge factor on `eael_days`.

This fudge factor is now applied in validation rather than in the FE, addressing #78 -- allowing no. of days < 15.

This fix should be removed asap and the data in the database corrected.