### PR TITLE
Tweak regional risk value formatting

### DIFF
--- a/containers/web-server/frontend/src/config/regional-risk/data-formats.ts
+++ b/containers/web-server/frontend/src/config/regional-risk/data-formats.ts
@@ -1,4 +1,5 @@
 import { FormatConfig } from '@/lib/data-map/view-layers';
+import { makeValueFormat } from '@/lib/formats';
 import { toLabelLookup } from '@/lib/helpers';
 
 import { REGIONAL_EXPOSURE_VARIABLE_LABELS } from './metadata';
@@ -8,6 +9,6 @@ const rexpLabelLookup = toLabelLookup(REGIONAL_EXPOSURE_VARIABLE_LABELS);
 export function getRegionalExposureDataFormats(): FormatConfig {
   return {
     getDataLabel: ({ field }) => rexpLabelLookup[field],
-    getValueFormatted: (value) => `${value}`,
+    getValueFormatted: makeValueFormat('_', {maximumFractionDigits: 1}),
   };
 }


### PR DESCRIPTION
A small PR for formatting the regional risk affected population with thousand separators, max fractional digits set to 1