### PR TITLE
Enforce node 16 when running npm install

### DIFF
--- a/containers/web-server/frontend/.npmrc
+++ b/containers/web-server/frontend/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/containers/web-server/frontend/package-lock.json
+++ b/containers/web-server/frontend/package-lock.json
@@ -70,6 +70,9 @@
         "react-app-rewired": "^2.2.1",
         "tsconfig-paths-webpack-plugin": "^4.0.0",
         "typescript": "^4.5.5"
+      },
+      "engines": {
+        "node": ">=16.0.0 <17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/containers/web-server/frontend/package.json
+++ b/containers/web-server/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "infra-risk-vis",
   "version": "0.2.0",
   "private": true,
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  },
   "dependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",


### PR DESCRIPTION
This will cause an error when trying to run `npm install` in an environment with a different version of Node than v16.x.x
Helps prevent problems in development with local node version mismatches. 