### PR TITLE
Allow data value formatting result to be ReactNode

### DIFF
--- a/containers/web-server/frontend/src/config/regional-risk/data-formats.ts
+++ b/containers/web-server/frontend/src/config/regional-risk/data-formats.ts
@@ -1,5 +1,5 @@
 import { FormatConfig } from '@/lib/data-map/view-layers';
-import { makeValueFormat } from '@/lib/formats';
+import { makeValueFormat, nullFormat } from '@/lib/formats';
 import { toLabelLookup } from '@/lib/helpers';
 
 import { REGIONAL_EXPOSURE_VARIABLE_LABELS } from './metadata';
@@ -9,6 +9,6 @@ const rexpLabelLookup = toLabelLookup(REGIONAL_EXPOSURE_VARIABLE_LABELS);
 export function getRegionalExposureDataFormats(): FormatConfig {
   return {
     getDataLabel: ({ field }) => rexpLabelLookup[field],
-    getValueFormatted: makeValueFormat('_', {maximumFractionDigits: 1}),
+    getValueFormatted: nullFormat(makeValueFormat('_', { maximumFractionDigits: 1 })),
   };
 }

--- a/containers/web-server/frontend/src/lib/data-map/view-layers.ts
+++ b/containers/web-server/frontend/src/lib/data-map/view-layers.ts
@@ -40,7 +40,7 @@ export interface DataManager {
 
 export interface FormatConfig<D = any> {
   getDataLabel: (fieldSpec: FieldSpec) => string;
-  getValueFormatted: (value: D, fieldSpec: FieldSpec) => string;
+  getValueFormatted: (value: D, fieldSpec: FieldSpec) => string | ReactNode;
 }
 
 export type ViewLayerDataAccessFunction = (fieldSpec: FieldSpec) => Accessor<any>;


### PR DESCRIPTION
Fixes a type error due to a previous change to regional risk summary value formatting config.

The `FormatConfig` type only accepted string results for value formatting.
This PR changes that to also accept `ReactNode` - so that HTML-formatted strings are allowed (for example `km<sup>2</sup>` for square kilometres).