### PR TITLE
0.2.5

### DIFF
--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -43,7 +43,7 @@ services:
       - "traefik.http.routers.web-server.entrypoints=websecure"
       - "traefik.http.routers.web-server.tls.certresolver=certresolverone"
       - "traefik.http.services.web-server.loadbalancer.server.port=80"
-    cpus: 1.0
+    cpus: 0.25
     mem_reservation: "50M"
     mem_limit: "250M"
 
@@ -64,7 +64,7 @@ services:
       - "traefik.http.routers.backend.middlewares=backend-stripprefix"
       - "traefik.http.middlewares.backend-stripprefix.stripprefix.prefixes=/api"
       - "traefik.http.services.backend.loadbalancer.server.port=8888"
-    cpus: 1.0
+    cpus: 0.5
     mem_reservation: "50M"
     mem_limit: "500M"
 
@@ -83,24 +83,25 @@ services:
       - "traefik.http.routers.vector-tileserver.middlewares=vector-tileserver-stripprefix"
       - "traefik.http.middlewares.vector-tileserver-stripprefix.stripprefix.prefixes=/vector"
       - "traefik.http.services.vector-tileserver.loadbalancer.server.port=8080"
-    cpus: 1.0
+    cpus: 0.5
     mem_reservation: "50M"
     mem_limit: "500M"
 
   # IRV AUTOPACKAGE Services
 
   redis:
-    image: redis:6.2-alpine
+    image: ghcr.io/nismod/irv-autopkg-redis:0.1
+    user: autopkg
     restart: always
     command: redis-server --save 20 1 --loglevel notice
     volumes: 
       - ./irv-autopkg/redis:/data
-    cpus: "0.25"
+    cpus: 0.25
     mem_reservation: "50M"
     mem_limit: "250M"
 
   irv-autopkg-worker:
-    image: ghcr.io/nismod/irv-autopkg:0.2.3
+    image: ghcr.io/nismod/irv-autopkg:0.2.5
     restart: always
     user: autopkg
     volumes:
@@ -109,12 +110,12 @@ services:
     env_file:
       - envs/prod/.irv-autopkg.env
     command: celery --app dataproc.tasks worker
-    cpus: 1.0
-    mem_reservation: "500M"
-    mem_limit: "5G"
+    cpus: 2.0
+    mem_reservation: "1G"
+    mem_limit: "4G"
 
   irv-autopkg-api:
-    image: ghcr.io/nismod/irv-autopkg:0.2.3
+    image: ghcr.io/nismod/irv-autopkg:0.2.5
     restart: always
     user: autopkg
     volumes:

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   traefik:
     image: "traefik:v2.9"
+    restart: always
     container_name: "traefik"
     command:
       - "--log.level=DEBUG"
@@ -24,9 +25,14 @@ services:
     volumes:
       - "./letsencrypt:/letsencrypt"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    cpus: 0.25
+    mem_reservation: "50M"
+    mem_limit: "250M"
+
 
   web-server:
     image: ghcr.io/nismod/gri-web-server:0.17
+    restart: always
     expose:
       - "80"
     volumes:
@@ -37,9 +43,13 @@ services:
       - "traefik.http.routers.web-server.entrypoints=websecure"
       - "traefik.http.routers.web-server.tls.certresolver=certresolverone"
       - "traefik.http.services.web-server.loadbalancer.server.port=80"
+    cpus: 1.0
+    mem_reservation: "50M"
+    mem_limit: "250M"
 
   backend:
     image: ghcr.io/nismod/gri-backend:0.9
+    restart: always
     volumes:
       - ./tileserver/raster/data:/data
     env_file:
@@ -54,9 +64,13 @@ services:
       - "traefik.http.routers.backend.middlewares=backend-stripprefix"
       - "traefik.http.middlewares.backend-stripprefix.stripprefix.prefixes=/api"
       - "traefik.http.services.backend.loadbalancer.server.port=8888"
+    cpus: 1.0
+    mem_reservation: "50M"
+    mem_limit: "500M"
 
   vector-tileserver:
     image: ghcr.io/nismod/gri-vector-tileserver:0.10
+    restart: always
     volumes:
       - ./tileserver/vector/data:/data
     expose:
@@ -69,6 +83,9 @@ services:
       - "traefik.http.routers.vector-tileserver.middlewares=vector-tileserver-stripprefix"
       - "traefik.http.middlewares.vector-tileserver-stripprefix.stripprefix.prefixes=/vector"
       - "traefik.http.services.vector-tileserver.loadbalancer.server.port=8080"
+    cpus: 1.0
+    mem_reservation: "50M"
+    mem_limit: "500M"
 
   # IRV AUTOPACKAGE Services
 
@@ -78,9 +95,13 @@ services:
     command: redis-server --save 20 1 --loglevel notice
     volumes: 
       - ./irv-autopkg/redis:/data
+    cpus: "0.25"
+    mem_reservation: "50M"
+    mem_limit: "250M"
 
   irv-autopkg-worker:
     image: ghcr.io/nismod/irv-autopkg:0.2.3
+    restart: always
     user: autopkg
     volumes:
       - ./irv-autopkg/packages:/data/packages
@@ -88,9 +109,13 @@ services:
     env_file:
       - envs/prod/.irv-autopkg.env
     command: celery --app dataproc.tasks worker
+    cpus: 1.0
+    mem_reservation: "500M"
+    mem_limit: "5G"
 
   irv-autopkg-api:
     image: ghcr.io/nismod/irv-autopkg:0.2.3
+    restart: always
     user: autopkg
     volumes:
       - ./irv-autopkg/packages:/data/packages
@@ -108,3 +133,6 @@ services:
       - "traefik.http.routers.irv-autopkg-api.middlewares=irv-autopkg-api-stripprefix"
       - "traefik.http.middlewares.irv-autopkg-api-stripprefix.stripprefix.prefixes=/extract"
       - "traefik.http.services.irv-autopkg-api.loadbalancer.server.port=8000"
+    cpus: 0.25
+    mem_reservation: "50M"
+    mem_limit: "250M"

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -80,19 +80,21 @@ services:
       - ./irv-autopkg/redis:/data
 
   irv-autopkg-worker:
-    image: ghcr.io/nismod/irv-autopkg:0.1.0
+    image: ghcr.io/nismod/irv-autopkg:0.2.3
+    user: autopkg
     volumes:
       - ./irv-autopkg/packages:/data/packages
-      - ./irv-autopkg/tmp:/data/tmp
+      - ./irv-autopkg/processing:/data/processing
     env_file:
       - envs/prod/.irv-autopkg.env
-    command: celery --app dataproc.tasks worker --loglevel=info --concurrency=4
+    command: celery --app dataproc.tasks worker
 
   irv-autopkg-api:
-    image: ghcr.io/nismod/irv-autopkg:0.1.0
+    image: ghcr.io/nismod/irv-autopkg:0.2.3
+    user: autopkg
     volumes:
       - ./irv-autopkg/packages:/data/packages
-      - ./irv-autopkg/tmp:/data/tmp
+      - ./irv-autopkg/processing:/data/processing
     env_file:
       - envs/prod/.irv-autopkg.env
     expose:


### PR DESCRIPTION
Image Version bump from IRV-Autopackage:

- S3 Support
- Raster Cropping Optimisations
- Vector Cropping Optimisations
- Redis Image as non-root
- Resource limits for CPU & Mem across all Services (see comment from Tom R on this PR: https://github.com/nismod/infra-risk-vis/pull/150/#pullrequestreview-1307294700)

