### PR TITLE
consistent route for metadata creation across ETL rules

### DIFF
--- a/envs/dev-example/.etl.env
+++ b/envs/dev-example/.etl.env
@@ -14,9 +14,9 @@ PGDATABASE=global
 PGUSER=docker
 PGPASSWORD=docker
 
-# connecting to `backend`
-BE_HOST=localhost
-BE_PORT=8888
+# ultimately connecting to `backend`, but via proxy server or traefik
+GATEWAY_HOST=localhost
+GATEWAY_PORT=5173
 BE_API_TOKEN=test  # required for mutation operations on tile metadata (`/tiles/sources POST & DELETE`).
 
 # data downloading

--- a/etl/README.md
+++ b/etl/README.md
@@ -103,9 +103,9 @@ PGDATABASE=global
 PGUSER=docker
 PGPASSWORD=docker
 
-# connecting to `backend`
-BE_HOST=localhost
-BE_PORT=8888
+# ultimately connecting to `backend`, but via frontend dev proxy server or `traefik`
+GATEWAY_HOST=localhost
+GATEWAY_PORT=5173
 BE_API_TOKEN=test  # required for mutation operations on tile metadata (`/tiles/sources POST & DELETE`).
 
 # data downloading

--- a/etl/README.md
+++ b/etl/README.md
@@ -52,10 +52,11 @@ micromamba activate irv-etl
 
 ### Required services
 
-The later stages of the ETL pipeline involve interacting with services
-defined in the parent directory to this one. The `backend` service acts as an
-intermediary to two databases, a `postgreSQL` and a `mysql` instance, known as
-the `db` and `tiles-db` services respectively.
+The last two stages of the ETL pipeline (ingestion and metadata creation)
+involve interacting with services defined in the parent directory to this one.
+
+The `backend` service acts as an intermediary to two databases, a `postgreSQL`
+and a `mysql` instance, known as the `db` and `tiles-db` services respectively.
 
 To bring up these services, refer to the [readme](../README.md) in the parent
 directory for a full explanation of their required env files, etc., but briefly:
@@ -63,6 +64,11 @@ directory for a full explanation of their required env files, etc., but briefly:
 ```bash
 docker compose -f docker-compose-dev.yaml up db tiles-db backend
 ```
+
+If you are creating metadata records (the final step) you will also need a
+[frontend development server](https://github.com/nismod/irv-frontend) or
+traefik to act as a reverse proxy to redirect requests for
+`GATEWAY_HOST:GATEWAY_PORT/api/<path>` to `backend:8888/<path>`.
 
 ### Awkward files
 

--- a/etl/database.smk
+++ b/etl/database.smk
@@ -52,7 +52,7 @@ rule POST_metadata_to_backend:
         flag = "raster/metadata/{DATASET}.flag"
     shell:
         """
-        http --check-status --follow POST http://$BE_HOST:$BE_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.metadata}
+        http --check-status --follow POST http://$GATEWAY_HOST:$GATEWAY_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.metadata}
 
         touch {output.flag}
         """

--- a/etl/pipelines/aqueduct/rules.smk
+++ b/etl/pipelines/aqueduct/rules.smk
@@ -102,8 +102,8 @@ rule POST_metadata_to_backend:
         flag = "raster/metadata/aqueduct.flag"
     shell:
         """
-        http --check-status --follow POST http://$BE_HOST:$BE_PORT/tiles/sources x-token:$BE_API_TOKEN < {input.fluvial_metadata}
-        http --check-status --follow POST http://$BE_HOST:$BE_PORT/tiles/sources x-token:$BE_API_TOKEN < {input.coastal_metadata}
+        http --check-status --follow POST http://$GATEWAY_HOST:$GATEWAY_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.fluvial_metadata}
+        http --check-status --follow POST http://$GATEWAY_HOST:$GATEWAY_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.coastal_metadata}
 
         touch {output.flag}
         """

--- a/etl/pipelines/isimip/rules.smk
+++ b/etl/pipelines/isimip/rules.smk
@@ -36,8 +36,8 @@ rule POST_metadata_to_backend:
         flag = "raster/metadata/isimip.flag"
     shell:
         """
-        http --check-status --follow POST http://$BE_HOST:$BE_PORT/tiles/sources x-token:$BE_API_TOKEN < {input.heat_metadata}
-        http --check-status --follow POST http://$BE_HOST:$BE_PORT/tiles/sources x-token:$BE_API_TOKEN < {input.drought_metadata}
+        http --check-status --follow POST http://$GATEWAY_HOST:$GATEWAY_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.heat_metadata}
+        http --check-status --follow POST http://$GATEWAY_HOST:$GATEWAY_PORT/api/tiles/sources x-token:$BE_API_TOKEN < {input.drought_metadata}
 
         touch {output.flag}
         """


### PR DESCRIPTION
In the ETL process there are 3 rules which create metadata entries, each called something like `POST_metadata_to_backend`. 1 for ISIMIP, 1 for Aqueduct and 1 for every other dataset.

I had stripped out the leading `/api` from `/api/tiles/sources` for the dataset specific routes used to create metadata for the dataset specific routes for a particular configuration of services locally. This was useful if you wanted to direct the request at the `backend` service directly (say if there is no frontend). It is not ideal when creating metadata entries on a remote, where you are more likely to need to pass through a reverse proxy (which needs the `/api` for routing to the appropriate service).

Change to have `/api/tiles/sources` consistently as the route, and change documentation and env variable names to make clear you need a proxy of some kind. This allows ETL to interact with local and remote instances with only configuration changes.