### PR TITLE
Fix backend errors

### DIFF
--- a/containers/backend/Dockerfile
+++ b/containers/backend/Dockerfile
@@ -3,10 +3,13 @@ LABEL maintainer="frederick.thomas@ouce.ox.ac.uk"
 
 WORKDIR /code
 
+# Install project with dependencies - these can be cached as docker layers if unchanged
 COPY pyproject.toml .
-
 RUN python -m pip install .
+
+# Copy and install latest package code
 COPY ./backend /code/backend
+RUN python -m pip install --upgrade --compile .
 
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8888"]
 

--- a/containers/backend/backend/app/routers/tiles.py
+++ b/containers/backend/backend/app/routers/tiles.py
@@ -16,6 +16,7 @@ from sqlalchemy import select, func
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 from geoalchemy2 import functions
+from terracotta.exceptions import DatasetNotFoundError
 
 
 from app import schemas
@@ -401,6 +402,12 @@ async def get_tile(
         raise HTTPException(
             status_code=400,
             detail=f"source database {source_db} does not exist in tiles metastore",
+        )
+    except DatasetNotFoundError as err:
+        handle_exception(logger, err)
+        raise HTTPException(
+            status_code=400,
+            detail=f"layer with keys {parsed_keys} not found in {source_db} in tiles metastore",
         )
     except Exception as err:
         handle_exception(logger, err)

--- a/containers/backend/backend/app/routers/tiles.py
+++ b/containers/backend/backend/app/routers/tiles.py
@@ -101,18 +101,18 @@ def _tile_db_from_domain(domain: str) -> str:
     """
     # TODO try conventional or configured mappin again - hot fix for db pool exhaustion
     domain_to_db = {
-        "buildings": "buildings",
-        "coastal": "aqueduct",
-        "cyclone_iris": "iris",
-        "cyclone": "cyclone",
-        "drought": "drought",
-        "earthquake": "gem_earthquake",
-        "extreme_heat": "extreme_heat",
-        "fluvial": "aqueduct",
-        "land_cover": "land_cover",
-        "nature": "exposure_nature",
-        "population": "jrc_pop",
-        "traveltime_to_healthcare": "traveltime_to_healthcare",
+        "buildings": "terracotta_buildings",
+        "coastal": "terracotta_aqueduct",
+        "cyclone_iris": "terracotta_iris",
+        "cyclone": "terracotta_cyclone",
+        "drought": "terracotta_drought",
+        "earthquake": "terracotta_gem_earthquake",
+        "extreme_heat": "terracotta_extreme_heat",
+        "fluvial": "terracotta_aqueduct",
+        "land_cover": "terracotta_land_cover",
+        "nature": "terracotta_exposure_nature",
+        "population": "terracotta_jrc_pop",
+        "traveltime_to_healthcare": "terracotta_traveltime_to_healthcare",
     }
     return domain_to_db[domain]
 

--- a/containers/backend/backend/app/routers/tiles.py
+++ b/containers/backend/backend/app/routers/tiles.py
@@ -105,6 +105,7 @@ def _tile_db_from_domain(domain: str) -> str:
         "coastal": "terracotta_aqueduct",
         "cyclone_iris": "terracotta_iris",
         "cyclone": "terracotta_cyclone",
+        "dem": "terracotta_dem",
         "drought": "terracotta_drought",
         "earthquake": "terracotta_gem_earthquake",
         "extreme_heat": "terracotta_extreme_heat",

--- a/containers/backend/backend/app/schemas.py
+++ b/containers/backend/backend/app/schemas.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar, Union
 from pydantic import BaseModel, ConfigDict, conint, validator
 
 
@@ -7,7 +7,7 @@ class FeatureBase(BaseModel):
     id: int
     string_id: str
     layer: str
-    sublayer: str | None
+    sublayer: Optional[str] = None
     properties: dict
 
 
@@ -33,7 +33,7 @@ class DataParameters(BaseModel):
 class ExpectedDamagesDimensions(DataDimensions):
     hazard: str
     rcp: str
-    epoch: str
+    epoch: Union[str, int]
     protection_standard: int
 
 
@@ -54,7 +54,7 @@ class ExpectedDamage(ExpectedDamagesDimensions, ExpectedDamagesVariables):
 class ReturnPeriodDamagesDimensions(DataDimensions):
     hazard: str
     rcp: str
-    epoch: str
+    epoch: Union[str, int]
     rp: int
 
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -46,7 +46,7 @@ services:
 
   backend:
     build: ./containers/backend
-    image: ghcr.io/nismod/gri-backend:1.3
+    image: ghcr.io/nismod/gri-backend:1.4.2
     volumes:
       - ./etl/raster/cog/:/data/
       - ./containers/backend/backend/:/code/backend/

--- a/docker-compose-prod-build.yaml
+++ b/docker-compose-prod-build.yaml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ghcr.io/nismod/gri-backend:1.3
+    image: ghcr.io/nismod/gri-backend:1.4.2
     build: ./containers/backend
 
   vector-tileserver:

--- a/docker-compose-prod-deploy.yaml
+++ b/docker-compose-prod-deploy.yaml
@@ -45,7 +45,7 @@ services:
     mem_limit: "250M"
 
   backend:
-    image: ghcr.io/nismod/gri-backend:1.3
+    image: ghcr.io/nismod/gri-backend:1.4.2
     restart: always
     volumes:
       - ./tileserver/raster/data:/data


### PR DESCRIPTION
- features api was giving errors with schema validation [`GET /api/features/51235929`](https://global.infrastructureresilience.org/api/features/51235929)
- database pool was getting exhausted, not immediately obvious where connections were leaking as all should have been cleaned up by FastAPI `Depends`, but the recent change was in the `/api/tiles/.../*.png` call, so rolled back to a hard-coded lookup for now.