### PR TITLE
Add JRC global river flood and World Bank/ARUP global landslide hazard maps

### DIFF
--- a/containers/backend/backend/app/routers/tiles.py
+++ b/containers/backend/backend/app/routers/tiles.py
@@ -84,6 +84,7 @@ def _tile_db_from_domain(domain: str) -> str:
         "dem": "terracotta_dem",
         "earthquake": "terracotta_earthquake",
         "isimip": "terracotta_isimip",
+        "jrc_flood": "terracotta_jrc_flood",
         "land_cover": "terracotta_land_cover",
         "nature": "terracotta_nature",
         "population": "terracotta_population",

--- a/etl/Snakefile
+++ b/etl/Snakefile
@@ -55,6 +55,12 @@ module isimip:
 use rule * from isimip as isimip_*
 
 
+module jrc_flood:
+    snakefile: "pipelines/jrc_flood/rules.smk"
+    config: config
+use rule * from jrc_flood as jrc_flood_*
+
+
 module land_cover:
     snakefile: "pipelines/land_cover/rules.smk"
     config: config
@@ -105,6 +111,7 @@ ALL_DATASETS = (
     "ghsl_pop",
     "iris",
     "isimip",
+    "jrc_flood",
     "land_cover",
     "nature",
     "storm",

--- a/etl/pipelines/jrc_flood/README.md
+++ b/etl/pipelines/jrc_flood/README.md
@@ -1,0 +1,107 @@
+# JRC Global River Flood
+
+Global river flood hazard maps is a gridded data set representing inundation
+along the river network, for seven different flood return periods. The input
+river flow data for the new maps are produced by means of the open-source
+hydrological model LISFLOOD, while inundation simulations are performed with the
+hydrodynamic model LISFLOOD-FP.
+
+## Citation
+
+Baugh, Calum; Colonese, Juan; D'Angelo, Claudia; Dottori, Francesco; Neal,
+Jeffrey; Prudhomme, Christel; Salamon, Peter (2024): Global river flood hazard
+maps. European Commission, Joint Research Centre (JRC) [Dataset] PID:
+http://data.europa.eu/89h/jrc-floods-floodmapgl_rp50y-tif
+
+## Metadata
+
+GENERAL INFORMATION
+
+G01. Dataset version 2.0.0
+G02. Name of the dataset: Global river flood hazard maps
+G03. Description of the dataset: Global river flood hazard maps is a gridded data set representing inundation along the river network, for seven different flood return periods. The input river flow data for the new maps are produced by means of the open-source hydrological model LISFLOOD, while inundation simulations are performed with the hydrodynamic model LISFLOOD-FP.
+G04. Creator of data set: Copernicus Emergency Management Service
+G05. DOI of dataset: NA
+G06. PID of dataset: NA
+G07. Keywords (author defined): riverine flood, hazard, global
+G08. Language(s) used in the dataset: English
+G09. Last update of the README file: 14.03.2024
+
+DATA DESCRIPTION
+
+D01. Horizontal coverage: Global
+D02. Horizontal resolution: 3 arc seconds (~90 m)
+D03. Spatial gaps: Only land areas are covered by this data set
+D04. Temporal coverage: NA
+D05. Temporal resolution: NA
+D06. Temporal gaps: NA
+D07. Number of available variables: 1 (flood water depth)
+D08. Variables available at daily resolution: NA
+D09. Variables available at 6-hourly resolution: NA
+D10. Units: meters
+D11. Update frequency: irregular
+D12. Projection: wgs_1984
+D13. Data type: 3 arc seconds (~90m) grid
+D14. Available version(s): 2
+
+PROJECT INFORMATION
+
+P01. Project information: Global river flood hazard maps have been produced as part of the Global Flood Awareness System (GloFAS) of the Copernicus Emergency Management Service.
+P02. Project website: https://emergency.copernicus.eu/
+P03. Project funder: European Commission
+
+FILE OVERVIEW
+
+F01. Number of files described by the README-file: 266 files per return period. Files are stored in folders for each return period.
+F02. The different files represent the tiles for the flood hazard maps for different return periods and the permanent water bodies used to patch the flood hazard maps for permanent water bodies
+F03. Naming conventions for file names: <IDXXX_N/SXX_E/WXX_RPXXX>\_depth.tif
+F04. Explanation of abbreviations: RP = Return period, XXX denotes the return period year or the tile identifier, N/S/W/E - North/South/East/West;
+F05. File formats: Tagged Image File Format tif
+F06. Software necessary to open the file: any software that opens tif, e.g. ArcGIS, QGIS etc.
+
+STORAGE INFORMATION
+
+S01. Where are the data stored?: JRC Data Store, https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/CEMS-GLOFAS/flood_hazard/
+
+DATA ACCESS AND SHARING
+
+A01. Recommended citation for the dataset: Baugh, Calum; Colonese, Juan; D'Angelo, Claudia; Francesco, Dottori; Neal, Jeffrey; Prudhomme; Christe; Salamon, Peter (2024): Modelled flood inundation for different return period scenarios at the global scale. European Commission, Joint Research Centre (JRC)
+A02. License information, restrictions on use: no restrictions, free and open Copernicus product
+A03. Copyright statement: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/CEMS-GLOFAS/copyright.txt
+A04. User support service: contact person outlined in the JRC Data Catalogue
+
+RELATIONSHIPS
+
+R01. Reference publication of this dataset: Baugh, Calum; Colonese, Juan; D'Angelo, Claudia; Francesco, Dottori; Neal, Jeffrey; Prudhomme, Christel; Salamon, Peter. (2024): An updated dataset of global and European flood hazard maps. Manuscript under preparation.
+R02. Grimaldi, Stefania; Salamon, Peter; Disperati, Juliana; Zsoter, Ervin; Russo, Carlo; Ramos, Arthur; Carton, Corentin; Barnard, Chris; Hansford, Eleanor; Gomes, Goncalo; Prudhomme, Christel (2022): GloFAS v4.0 hydrological reanalysis. European Commission, Joint Research Centre (JRC) [Dataset] PID: http://data.europa.eu/89h/f96b7a19-0133-4105-a879-0536991ca9c5
+R03. This dataset incorporates the following other datasets: MERIT-DEM, MERIT-HYDRO, GloFAS v4.0 hydrological reanalysis
+
+## Copyright notice
+
+(c) European Union, 1995-2024
+
+The Commission's reuse policy is implemented by the Commission Decision of 12 December 2011
+on the reuse of Commission documents [1]. Any copyright and/or sui generis right on the dataset
+is licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0) licence [2].
+Reuse is allowed provided appropriate credit is given and any changes are indicated.
+
+[1] https://eur-lex.europa.eu/eli/dec/2011/833/oj
+[2] https://creativecommons.org/licenses/by/4.0
+
+## Changelog
+
+### V2.0.0 (2024-03-14)
+
+Release of the updated global flood hazard maps. A description of the dataset
+is currently being prepared as manuscript: Baugh, Calum; Colonese, Juan;
+D'Angelo, Claudia; Francesco, Dottori; Neal, Jeffrey; Prudhomme, Christel;
+Salamon, Peter. (2024): An updated dataset of global and European flood hazard
+maps. Manuscript under preparation
+
+### v1.0.0 (2016-05-15)
+
+Initial release of the global flood hazard maps. A detailed description of the
+maps and the methodology can be found in: Dottori F, Salamon P, Bianchi A,
+Alfieri L, Hirpa F, Feyen L. Development and evaluation of a framework for
+global flood hazard mapping. ADVANCES IN WATER RESOURCES 94; 2016. p. 87-102.
+ISSN 0309-1708, https://doi.org/10.1016/j.advwatres.2016.05.002.

--- a/etl/pipelines/jrc_flood/layers.csv
+++ b/etl/pipelines/jrc_flood/layers.csv
@@ -1,0 +1,7 @@
+filename,rp
+floodMapGL_rp10y.tif,10
+floodMapGL_rp20y.tif,20
+floodMapGL_rp50y.tif,50
+floodMapGL_rp100y.tif,100
+floodMapGL_rp200y.tif,200
+floodMapGL_rp500y.tif,500

--- a/etl/pipelines/jrc_flood/metadata.json
+++ b/etl/pipelines/jrc_flood/metadata.json
@@ -1,0 +1,8 @@
+{
+  "domain": "jrc_flood",
+  "name": "JRC Global river flood hazard maps",
+  "group": "Hazard",
+  "description": "Baugh, C., Colonese, J., D'Angelo, C., Dottori, F., Neal, J., Prudhomme, C., Salamon, P. (2024): Global river flood hazard maps. European Commission, Joint Research Centre (JRC) [Dataset] PID: http://data.europa.eu/89h/jrc-floods-floodmapgl_rp50y-tif",
+  "license": "CC-BY 4.0 International",
+  "keys": ["rp"]
+}

--- a/etl/pipelines/jrc_flood/rules.smk
+++ b/etl/pipelines/jrc_flood/rules.smk
@@ -1,0 +1,26 @@
+rule download:
+    output:
+        zip="raster/raw/jrc_flood/floodMapGL_rp{RP}y.zip"
+    shell:
+        """
+        output_dir=$(dirname {output.zip})
+
+        wget -q -nc \
+            --directory-prefix=$output_dir \
+            https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/FLOODS/GlobalMaps/floodMapGL_rp{wildcards.RP}y.zip
+        """
+
+rule extract:
+    input:
+        tiff="raster/raw/jrc_flood/floodMapGL_rp{RP}y.zip"
+    output:
+        tiff="raster/raw/jrc_flood/floodMapGL_rp{RP}y.tif"
+    shell:
+        """
+        output_dir=$(dirname {output.tiff})
+        unzip $output_dir/floodMapGL_rp{wildcards.RP}y.zip floodMapGL_rp{wildcards.RP}y.tif -d $output_dir
+        """
+
+rule all:
+    input:
+        tiffs=expand("raster/raw/jrc_flood/floodMapGL_rp{RP}y.tif", RP=[10, 20, 50, 100, 200, 500])

--- a/etl/pipelines/landslide_arup/README.md
+++ b/etl/pipelines/landslide_arup/README.md
@@ -1,0 +1,70 @@
+# Global Landslide Hazard Maps
+
+https://datacatalog.worldbank.org/dataset/global-landslide-hazard-map
+
+The Global Landslide hazard map is a gridded dataset of landslide hazard produced
+at the global scale. Landslides happen around the world and have devastating
+impacts on people and the built environment. To better understand the spatial
+and temporal distribution of landslide hazard worldwide, the World Bank and the
+Global Facility for Disaster Reduction and Recovery (GFDRR) commissioned Arup to
+undertake a landslide hazard assessment at a global scale. Using a global
+landslide inventory, landslide susceptibility information provided by NASA, and
+an innovative machine learning model, our geohazard and risk management experts
+produced a state-of-the-art quantitative landslide hazard map for the whole
+world.
+
+The dataset comprises gridded maps of estimated annual frequency of significant
+landslides per square kilometre. Significant landslides are those which are
+likely to have been reported had they occurred in a populated place; limited
+information on reported landslide size makes it difficult to tie frequencies to
+size ranges but broadly speaking would be at least greater than 100 m2. The data
+provides frequency estimates for each grid cell on land between 60?S and 72?N
+for landslides triggered by seismicity and rainfall. Applications of this
+dataset include improved hazard screening based on frequency and severity,
+consistent national, regional and global scale exposure assessment, estimates of
+annual expected impact on population and the built environment.
+
+The dataset is publicly available for download and use and it consists of 4 global map layers:
+
+- Mean annual rainfall-triggered landslide hazard (1980 ? 2018): raster values
+  represent the modelled average annual frequency of significant
+  rainfall-triggered landslides per sq. km.
+- Median annual rainfall-triggered landslide hazard (1980 ? 2018): raster values
+  represent the modelled median annual frequency of significant
+  rainfall-triggered landslides per sq. km.
+- Mean annual earthquake-triggered landslide hazard: raster values represent the
+  modelled average annual frequency of significant earthquake-triggered
+  landslides per sq. km.
+- Aggregate hazard index ranging from 1 (low) to 4 (very high) implemented in
+  Thinkhazard! website (www.thinkhazard.org)
+
+A statistical relationship was developed between recorded landslides,
+susceptibility at the landslide location and daily rainfall in the prior days
+and weeks. Using the relationship, the daily probability of landslide occurrence
+per sq.km was estimated for the period 1980-2018. The dataset was validated
+against a number of local landslide catalogs and previous studies. The model
+suggests that in the order of 400,000 significant rainfall-triggered landslides
+occur globally per year. The average annual number of significant
+earthquake-triggered landslides is estimated to be in the order of 130,000.
+Based on the analysis of simulated daily rainfall, seasonality of landslide
+hazard in each country was summarized. Simulated trends in annual landslide
+frequency for the period 1980-2018 indicate an increase in landslide frequency
+due to changes in rainfall, particularly in southeast Asia since the mid-1990s.
+Beyond this period, the effects of climate change on landslide hazard were not
+explored.
+
+## Disclaimer
+
+The global hazard levels do not replace the need for detailed natural hazard
+risk analysis and/or expert advice at local scale. While the hazard level is
+scientifically determinef, there are still uncertainties in the data and
+analysis. Data users should access more information by contacting relevant
+national authorities, reviewing the recommended resources.
+
+The information contained in this dataset is provided for informational purposes
+only and does not constitute legal or scientific advice or service. The World
+Bank makes no warranties or representations, express or implied as to the
+accuracy or reliability of this tool or the data contained therein. Any use
+thereof or reliance thereon is at the sole and independent discretion and
+responsibility of the user. No conclusions or inferences drawn from this data
+should be attributed to the World Bank group.

--- a/etl/pipelines/landslide_arup/colourmap.csv
+++ b/etl/pipelines/landslide_arup/colourmap.csv
@@ -1,0 +1,5 @@
+value,label,r,g,b
+1,Very Low,100,100,80
+2,Low,100,80,55
+3,Medium,96,50,43
+4,High,83,35,45

--- a/etl/pipelines/landslide_arup/layers.csv
+++ b/etl/pipelines/landslide_arup/layers.csv
@@ -1,0 +1,5 @@
+filename,subtype
+ls_eq_tiled.tif,earthquake
+LS_RF_Mean_1980-2018_COG.tif,rainfall_mean
+LS_RF_Median_1980-2018_COG.tif,rainfall_median
+LS_TH_COG.tif,susceptibility

--- a/etl/pipelines/landslide_arup/metadata.json
+++ b/etl/pipelines/landslide_arup/metadata.json
@@ -1,0 +1,8 @@
+{
+  "domain": "landslide",
+  "name": "Global landslide hazard map",
+  "group": "Hazard",
+  "description": "Arup (2021) Global Landslide Hazard Map. Global Facility for Disaster Reduction and Recovery (GFDRR) and The World Bank.",
+  "license": "CC-BY 4.0",
+  "keys": ["subtype"]
+}

--- a/etl/pipelines/landslide_arup/rules.smk
+++ b/etl/pipelines/landslide_arup/rules.smk
@@ -1,0 +1,48 @@
+
+rule download_metadata:
+    output:
+        json="raster/raw/landslide_arup/metadata.json",
+    shell:
+        """
+        wget --output-document={output.json} \
+            https://datacatalogapi.worldbank.org/ddhxext/DatasetDownload?dataset_unique_id=0037584&version_id=
+        """
+
+rule download_landslides:
+    input:
+        json="raster/raw/landslide_arup/metadata.json",
+    output:
+        "raster/raw/landslide_arup/global-landslide-hazard-map-report.pdf",
+        "raster/raw/landslide_arup/ls_eq_tiled.tif",
+        "raster/raw/landslide_arup/LS_RF_Mean_1980-2018_COG.tif",
+        "raster/raw/landslide_arup/LS_RF_Median_1980-2018_COG.tif",
+        "raster/raw/landslide_arup/LS_TH_COG.tif",
+    run:
+        import json
+        import os
+        import zipfile
+        from pathlib import Path
+        import requests
+
+        with open(input.json, 'r') as fh:
+            meta = json.load(fh)
+
+        for file_meta in meta["resources"]:
+            fname = file_meta["distribution"]["file_name"]
+            url = file_meta["distribution"]["url"]
+            out_dir = "raster/raw/landslide"
+            out_file = os.path.join(out_dir, fname)
+
+            if Path(out_file).exists():
+                print("Skipped downloading", fname)
+            else:
+                print("Downloading", url)
+                r = requests.get(url)
+                with open(out_file, 'wb') as fd:
+                    for chunk in r.iter_content(chunk_size=1024):
+                        fd.write(chunk)
+
+            if ".zip" in fname:
+                print("Extracting zip", out_file)
+                with zipfile.ZipFile(out_file, 'r') as zh:
+                    zh.extractall(out_dir)


### PR DESCRIPTION
Consider categorical presentation of ARUP LS_TH_COG map (and/or underlying rainfall/earthquake-trigger probability maps) - this could be merged with just JRC though.