### PR TITLE
Update tileserver-gl, clean up vector tileserver config

### DIFF
--- a/containers/vector/Dockerfile
+++ b/containers/vector/Dockerfile
@@ -1,4 +1,4 @@
-FROM maptiler/tileserver-gl:v4.11.1
+FROM maptiler/tileserver-gl:v4.12.0
 LABEL maintainer="frederick.thomas@ouce.ox.ac.uk"
 
 # used in run.sh - override through docker compose if needed

--- a/containers/vector/config-dev.json
+++ b/containers/vector/config-dev.json
@@ -7,48 +7,5 @@
     }
   },
   "styles": {},
-  "data": {
-    "nbs_ls": {
-      "mbtiles": "nbs_ls.mbtiles"
-    },
-    "nbs_ls_points": {
-      "mbtiles": "nbs_ls_points.mbtiles"
-    },
-    "nbs_cf": {
-      "mbtiles": "nbs_cf.mbtiles"
-    },
-    "nbs_cf_points": {
-      "mbtiles": "nbs_cf_points.mbtiles"
-    },
-    "nbs_rf": {
-      "mbtiles": "nbs_rf.mbtiles"
-    },
-    "nbs_rf_points": {
-      "mbtiles": "nbs_rf_points.mbtiles"
-    },
-    "adm0": {
-      "mbtiles": "adm0.mbtiles"
-    },
-    "adm0_points": {
-      "mbtiles": "adm0_points.mbtiles"
-    },
-    "adm1": {
-      "mbtiles": "adm1.mbtiles"
-    },
-    "adm1_points": {
-      "mbtiles": "adm1_points.mbtiles"
-    },
-    "adm2": {
-      "mbtiles": "adm2.mbtiles"
-    },
-    "adm2_points": {
-      "mbtiles": "adm2_points.mbtiles"
-    },
-    "hybas": {
-      "mbtiles": "hybas.mbtiles"
-    },
-    "hybas_points": {
-      "mbtiles": "hybas_points.mbtiles"
-    }
-  }
+  "data": {}
 }


### PR DESCRIPTION
- update tileserver-gl Docker image to 4.12.0 which adds feature ID to the inspector view tooltip. Could potentially update to the latest version which is 5.1.3 if there are not breaking changes, but had limited ability to verify this
- cleaned up `config-dev.json` for vector tileserver - some leftover NBS datasets there, but originally this file should have an empty data configuration