### PR TITLE
Fix/pixel driller schema

### DIFF
--- a/containers/backend/backend/app/main.py
+++ b/containers/backend/backend/app/main.py
@@ -29,7 +29,7 @@ app = FastAPI(
     generate_unique_id_function=custom_generate_unique_id,
     title="GRI Infra-Risk-Vis API",
     description="API Supporting Global Resilience Initiative Visualisation UI.  Serving geospatial features (inc. related damages) and raster tiles (via Terracotta)",
-    version="0.9.0",
+    version="0.10.0",
     terms_of_service="",
     contact={
         "name": "Tom Russell",

--- a/containers/backend/backend/app/routers/pixel_driller.py
+++ b/containers/backend/backend/app/routers/pixel_driller.py
@@ -131,7 +131,7 @@ def query_zarr_pixel(
 
 @router.get(
     "/point/{lon}/{lat}",
-    # response_model=schemas.PixelDrillerResponse,
+    response_model=schemas.PixelDrillerResponse,
     response_class=ORJSONResponse,
 )
 def get_pixel_values(
@@ -185,12 +185,10 @@ def get_pixel_values(
     logger.debug(f"Completed processing all groups, total results: {len(all_results)}")
 
     try:
-        return ORJSONResponse(
-            {
-                "point": {"lat": lat, "lon": lon},
-                "results": list(itertools.chain.from_iterable(all_results)),
-            }
-        )
+        return {
+            "point": {"lat": lat, "lon": lon},
+            "results": list(itertools.chain.from_iterable(all_results)),
+        }
     except Exception as e:
         logger.error(f"Failed to create response: {e}")
         logger.debug(f"Response creation traceback:\n{traceback.format_exc()}")

--- a/containers/backend/backend/app/schemas.py
+++ b/containers/backend/backend/app/schemas.py
@@ -218,6 +218,11 @@ class PixelDrillerResult(BaseModel):
     layer: PixelDrillerLayer
 
 
+class Point(BaseModel):
+    lat: float
+    lon: float
+
+
 class PixelDrillerResponse(BaseModel):
-    point: dict[str, float]
+    point: Point
     results: list[PixelDrillerResult]


### PR DESCRIPTION
https://global.infrastructureresilience.org/api/openapi.json has `"/pixel-driller/point/{lon}/{lat}"` with no response schema

This PR should fix the schema metadata without affecting API performance. Currently WIP, reinstating the `response_model` and relying on `response_class` for ORJSON usage.